### PR TITLE
Ticket 1147: fixed test that was just passing all the time

### DIFF
--- a/RCPTT_Tests/AddingManyGroupsDoesNotCrashGui.test
+++ b/RCPTT_Tests/AddingManyGroupsDoesNotCrashGui.test
@@ -6,7 +6,7 @@ Element-Version: 3.0
 External-Reference: 
 Id: _YxmLoBE7EeaK56OpzmNTzg
 Runtime-Version: 2.0.1.201508250612
-Save-Time: 5/3/16 5:02 PM
+Save-Time: 5/9/16 4:51 PM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -30,10 +30,17 @@ let [val numberOfGroups 70] {
 	    }
 	}
 	
-	// Assert - All added groups are present (i.e. the GUI didn't crash)
-	get-window "New configuration" | get-group Groups | get-list | get-property "getItems().length" | equals $numberOfGroups 
-	    | verify-true
+	// Cannot base the assert on the number of items in the group list
+	// because even when they don't get displayed, the underlying group list has still the correct number of items!
 }  
-// Close the open dialog
+
+// Close the configuration dialog
+get-window "New configuration" | get-button Cancel | click
+
+// Assert - re-open the configuration dialog
+// If the UI has crashed, the automated test should not be able to reopen the dialog
+get-menu "Configuration/Configurations/New" | click
+
+// Final closing of dialog
 get-window "New configuration" | get-button Cancel | click
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--


### PR DESCRIPTION
To check that the UI does not crash when adding many groups, I was testing that the group list contained the correct number of items. However, if the UI crashes, even when the items don't get displayed, the underlying object checked by RCPTT still contains the correct number of items! So the test was just passing all the time.

I have changed the test to close and re-open the Configuration dialog. On my machine this test fails when there is a resource leak 
