### PR TITLE
Extend startup test wait time to 3 mins

### DIFF
--- a/RCPTT_Tests/Startup instrument is initially set up.test
+++ b/RCPTT_Tests/Startup instrument is initially set up.test
@@ -38,8 +38,8 @@ with [get-window "Load Configuration"] {
     get-button OK | click
 }
 
-// Can take a while for the instrument to update, wait 30s (sorry!)
-wait 30000
+// Can take a while for the instrument to update, wait 3 mins (sorry!)
+wait 180000
 
 get-view Dashboard | get-control Any -index 1 | get-property "getChildren().Control[0].getText()" 
     | contains "is   SETUP" | verify-true


### PR DESCRIPTION
Ticket 1241: The max time the GUI should wait to retest the PV is 2 mins. Wait for 3 minutes to try and be sure.
