### PR TITLE
Run AllTests suite so that tests run in correct order

### DIFF
--- a/runner.cmd
+++ b/runner.cmd
@@ -18,6 +18,6 @@ java -jar %RUNNER%/plugins/org.eclipse.equinox.launcher_1.3.100.v20150511-1540.j
  -autConsolePrefix %RESULTS%/aut-output ^
  -htmlReport %RESULTS%/report.html ^
  -junitReport %RESULTS%/report.xml ^
- -import %PROJECT%
+ -import %PROJECT% ^
  -suites AllTests
   

--- a/runner.cmd
+++ b/runner.cmd
@@ -19,4 +19,5 @@ java -jar %RUNNER%/plugins/org.eclipse.equinox.launcher_1.3.100.v20150511-1540.j
  -htmlReport %RESULTS%/report.html ^
  -junitReport %RESULTS%/report.xml ^
  -import %PROJECT%
+ -suites AllTests
   


### PR DESCRIPTION
Current settings run all tests with no ordering so defaults to alphabetical. As the tests are currently stateful, the order needs to be fixed
