### PR TITLE
removed references to summary tab

### DIFF
--- a/RCPTT_Tests/ConfigurationTests/DefaultSynopticAppearsInEditConfig.test
+++ b/RCPTT_Tests/ConfigurationTests/DefaultSynopticAppearsInEditConfig.test
@@ -6,7 +6,7 @@ Element-Version: 3.0
 External-Reference: 
 Id: _6ljosCF-EeaVDbdGJtxYOQ
 Runtime-Version: 2.0.1.201508250612
-Save-Time: 7/27/16 4:53 PM
+Save-Time: 10/11/16 1:16 PM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
@@ -14,8 +14,7 @@ Content-Type: text/ecl
 Entry-Name: .content
 
 with [edit_current_config] {
-	get-tab-folder | get-tab-item Summary | click
-	get-group Summary | get-combo -after [get-label "Synoptic:"] | get-property selection | equals "-- NONE --" | verify-true
+	get-combo -after [get-label "Synoptic:"] | get-property selection | equals "-- NONE --" | verify-true
 	get-button Cancel | click
 }
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/RCPTT_Tests/Contexts/ConfigProcedures.ctx
+++ b/RCPTT_Tests/Contexts/ConfigProcedures.ctx
@@ -6,7 +6,7 @@ Element-Type: context
 Element-Version: 2.0
 Id: _oJdLMEdZEeakK_49We-6tQ
 Runtime-Version: 2.0.1.201508250612
-Save-Time: 9/27/16 2:11 PM
+Save-Time: 10/11/16 1:42 PM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl
@@ -40,8 +40,7 @@ proc "edit_current_config" {
 proc "set_config_description" [val description] [val window -input true ] {
 	try -times 100 -delay 200 -command {
 		with $window {
-        	get-tab-folder | get-tab-item Summary | click
-    		get-group Summary | get-editbox -after [get-label "Description:"] | set-text $description
+			get-editbox -after [get-label "Description:"] | set-text $description
 	   	}
 	}
 }


### PR DESCRIPTION
### Description of work

Edited system tests to work with https://github.com/ISISComputingGroup/ibex_gui/pull/279. Specifically, removed references to the removed summary tab.
### To test

Related to ticket: https://github.com/ISISComputingGroup/IBEX/issues/1347

---
#### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code make use of existing procedures where appropriate?
- [ ] Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Does the name of the tests reflect what is actually being tested?
### Functional Tests
- [ ] Do the new tests pass on a GUI build containing the fix?
- [ ] Do the new tests fail on a GUI build NOT containing the fix (e.g. master)?
