### PR TITLE
Button label has changed

### DIFF
--- a/RCPTT_Tests/ConfigurationTests/CannotInsertDuplicateIntoCurrentConfigViaComponent.test
+++ b/RCPTT_Tests/ConfigurationTests/CannotInsertDuplicateIntoCurrentConfigViaComponent.test
@@ -6,7 +6,7 @@ Element-Version: 3.0
 External-Reference: 
 Id: _YyE5sBkcEeeBk98u4J3lxA
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 4/4/17 5:10 PM
+Save-Time: 5/30/17 10:59 AM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
@@ -61,7 +61,7 @@ let [val config01 [test_prefix "config01"]] [val comp01 [test_prefix "comp01"]] 
 	// Assert error
 	with [get-window "Conflicts with current configuration"] {
 		get-property "isVisible()" | equals true | verify-true
-		get-button Ok | click
+		get-button OK | click
 	}
 	get-window "Edit Component" | get-button Cancel | click
 	


### PR DESCRIPTION
### Description of work

As part of ticket #2264 I standardised the button labels "Ok" was changed to "OK"

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2374

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code make use of existing procedures where appropriate?
- [x] Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Does the name of the tests reflect what is actually being tested?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated to have entries equivalent to the system tests affected?
    - For example, remove manual tests that are covered by automated tests

### Functional Tests

- [x] Do the new tests pass on a GUI build containing the fix?
- [x] Do the new tests fail on a GUI build NOT containing the fix (e.g. master)?

