### PR TITLE
HACKATHON: Add scripting tests

### DIFF
--- a/RCPTT_Tests/AllTests.suite
+++ b/RCPTT_Tests/AllTests.suite
@@ -6,7 +6,7 @@ Element-Version: 2.0
 Id: _wMLmwPZgEeWOvoTG7aXu3Q
 Manually-Ordered: true
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/9/17 10:51 AM
+Save-Time: 6/14/17 11:38 AM
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8
 Content-Type: text/testcase
@@ -61,5 +61,6 @@ _UqzfICBrEeewH-_OS6CJKQ	// kind: 'test' name: 'CanOpenSynopticTargets' path: 'Sy
 _ZZsoUB-IEeeDtMdnkdf_bw	// kind: 'test' name: 'CanViewComponentIOCs' path: 'ConfigurationTests/CanViewComponentIOCs.test'
 _I072oExYEeehx9brc2-KyQ	// kind: 'test' name: 'WhenAConfigIsSavedAsAComponentThenComponentGroupsAreRemoved' path: 'GroupTests/WhenAConfigIsSavedAsAComponentThenComponentGroupsAreRemoved.test'
 _bpiCAEzwEee1irVDJO9Pmw	// kind: 'test' name: 'WhenComponetGroupRemovedItIsRemovedFromConfig' path: 'GroupTests/WhenComponetGroupRemovedItIsRemovedFromConfig.test'
+_OZJSQFDbEeebUsTjSlsNqg	// kind: 'test' name: 'CanGetAndSetBlocksFromTheScriptingPerspective' path: 'ScriptingTests/CanGetAndSetBlocksFromTheScriptingPerspective.test'
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8--

--- a/RCPTT_Tests/AllTests.suite
+++ b/RCPTT_Tests/AllTests.suite
@@ -6,7 +6,7 @@ Element-Version: 2.0
 Id: _wMLmwPZgEeWOvoTG7aXu3Q
 Manually-Ordered: true
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 1:24 PM
+Save-Time: 6/14/17 1:28 PM
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8
 Content-Type: text/testcase

--- a/RCPTT_Tests/AllTests.suite
+++ b/RCPTT_Tests/AllTests.suite
@@ -6,7 +6,7 @@ Element-Version: 2.0
 Id: _wMLmwPZgEeWOvoTG7aXu3Q
 Manually-Ordered: true
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 11:38 AM
+Save-Time: 6/14/17 1:24 PM
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8
 Content-Type: text/testcase
@@ -62,5 +62,6 @@ _ZZsoUB-IEeeDtMdnkdf_bw	// kind: 'test' name: 'CanViewComponentIOCs' path: 'Conf
 _I072oExYEeehx9brc2-KyQ	// kind: 'test' name: 'WhenAConfigIsSavedAsAComponentThenComponentGroupsAreRemoved' path: 'GroupTests/WhenAConfigIsSavedAsAComponentThenComponentGroupsAreRemoved.test'
 _bpiCAEzwEee1irVDJO9Pmw	// kind: 'test' name: 'WhenComponetGroupRemovedItIsRemovedFromConfig' path: 'GroupTests/WhenComponetGroupRemovedItIsRemovedFromConfig.test'
 _OZJSQFDbEeebUsTjSlsNqg	// kind: 'test' name: 'CanGetAndSetBlocksFromTheScriptingPerspective' path: 'ScriptingTests/CanGetAndSetBlocksFromTheScriptingPerspective.test'
+_trX9EFDxEeeRb7qwOt4j4g	// kind: 'test' name: 'CanControlRunFromScripting' path: 'ScriptingTests/CanControlRunFromScripting.test'
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8--

--- a/RCPTT_Tests/Contexts/ConfigProcedures.ctx
+++ b/RCPTT_Tests/Contexts/ConfigProcedures.ctx
@@ -6,7 +6,7 @@ Element-Type: context
 Element-Version: 2.0
 Id: _oJdLMEdZEeakK_49We-6tQ
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 11:14 AM
+Save-Time: 6/14/17 11:42 AM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl
@@ -209,8 +209,6 @@ proc add_ioc_no_macros [val ioc_name] [val window -input true] {
 	}
 	try -times 100 -delay 200 -command {
 		with [get_ioc_dialog] {
-        	get-button "Auto-Start" | check
-    		get-button "Auto-Restart" | check
 			get-button OK | check_enabled_and_click
 		}
 	}

--- a/RCPTT_Tests/Contexts/ConfigProcedures.ctx
+++ b/RCPTT_Tests/Contexts/ConfigProcedures.ctx
@@ -6,7 +6,7 @@ Element-Type: context
 Element-Version: 2.0
 Id: _oJdLMEdZEeakK_49We-6tQ
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/9/17 10:25 AM
+Save-Time: 6/14/17 11:14 AM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl
@@ -209,6 +209,8 @@ proc add_ioc_no_macros [val ioc_name] [val window -input true] {
 	}
 	try -times 100 -delay 200 -command {
 		with [get_ioc_dialog] {
+        	get-button "Auto-Start" | check
+    		get-button "Auto-Restart" | check
 			get-button OK | check_enabled_and_click
 		}
 	}

--- a/RCPTT_Tests/Contexts/IOCProcedures.ctx
+++ b/RCPTT_Tests/Contexts/IOCProcedures.ctx
@@ -1,0 +1,49 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Context-Type: org.eclipse.rcptt.ctx.ecl
+Element-Name: IOCProcedures
+Element-Type: context
+Element-Version: 2.0
+Id: _6GTDIFDlEeeRb7qwOt4j4g
+Runtime-Version: 2.1.0.201606221726
+Save-Time: 6/14/17 1:02 PM
+
+------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
+Content-Type: text/ecl
+Entry-Name: .ecl.context
+
+// Clicks a named button in the IOC control dialog
+// @param ioc The name of the ioc
+// @param button The button text
+proc control_ioc [val ioc] [val button] {
+	get-menu "IOC/Start\\/Stop IOCs" | click
+	with [get-window "Control IOCs"] {
+    	get-table | select $ioc
+    	check_enabled_and_click [get-button $button]
+    	get-button Close | click
+	}
+}
+
+// Starts a named ioc
+// @param ioc The name of the ioc
+proc "start_ioc" [val ioc] [val block] {
+	control_ioc $ioc "Start"
+	try -times 300 -delay 200 -command {
+		get-view Blocks | get-label -after [get-label [concat $block ":"]] | get-property "getText()" | equals disconnected | verify-false
+	}
+	
+	// Even after the block appears connected, instances of cgets showing disconnected have been encountered. Leave a couple of seconds' wait
+	// just in case
+    wait 10000
+}
+
+// Stop a named ioc
+// @param ioc The name of the ioc
+// @param block The name of a block used to verify the operation is complete
+proc "stop_ioc" [val ioc] [val block] {
+	control_ioc $ioc "Stop"
+	try -times 300 -delay 200 -command {
+		get-view Blocks | get-label -after [get-label [concat $block ":"]] | get-property "getText()" | equals disconnected | verify-true
+	}
+}
+------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998--

--- a/RCPTT_Tests/Contexts/InstrumentStatusProcedures.ctx
+++ b/RCPTT_Tests/Contexts/InstrumentStatusProcedures.ctx
@@ -5,8 +5,8 @@ Element-Name: InstrumentStatusProcedures
 Element-Type: context
 Element-Version: 2.0
 Id: _u7zXkB5uEeaqQYS4M76Ebw
-Runtime-Version: 2.0.1.201508250612
-Save-Time: 8/8/16 5:16 PM
+Runtime-Version: 2.1.0.201606221726
+Save-Time: 6/14/17 1:21 PM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl
@@ -25,6 +25,10 @@ proc "assert_instrument_is_setup" {
 
 proc "assert_instrument_is_running" {
 	assert_instrument_is "RUNNING"
+}
+
+proc "assert_instrument_is_paused" {
+	assert_instrument_is "PAUSED"
 }
 
 proc "assert_instrument_is_unknown" {

--- a/RCPTT_Tests/Contexts/SwitchToViewProcedures.ctx
+++ b/RCPTT_Tests/Contexts/SwitchToViewProcedures.ctx
@@ -6,7 +6,7 @@ Element-Type: context
 Element-Version: 2.0
 Id: _BgnBcB5tEeaAYI1qYj9bEg
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 3/31/17 4:33 PM
+Save-Time: 6/14/17 10:27 AM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl
@@ -14,9 +14,7 @@ Entry-Name: .ecl.context
 
 proc "switch_to_dae_view" { 
 	// Switch to DAE View
-	try -times 50 -delay 200 -command {
-	    get-label "DAE" | click
-	}
+	get-label "DAE" | click
 }
 
 proc "switch_to_device_screens_view" {
@@ -37,5 +35,10 @@ proc "switch_to_synoptic_view" {
 proc "switch_to_log_plotter_view" {
 	// Switch to log plotter view
 	get-label "Log Plotter" | click
+}
+
+proc "switch_to_scripting_view" {
+	// Switch to scripting view
+	get-label "Scripting" | click
 }
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998--

--- a/RCPTT_Tests/Contexts/SwitchToViewProcedures.ctx
+++ b/RCPTT_Tests/Contexts/SwitchToViewProcedures.ctx
@@ -6,7 +6,7 @@ Element-Type: context
 Element-Version: 2.0
 Id: _BgnBcB5tEeaAYI1qYj9bEg
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 10:27 AM
+Save-Time: 6/14/17 12:12 PM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl
@@ -40,5 +40,11 @@ proc "switch_to_log_plotter_view" {
 proc "switch_to_scripting_view" {
 	// Switch to scripting view
 	get-label "Scripting" | click
+
+	// Wait for the scripting window to finish starting
+	try -times 100 -delay 200 -command {
+		get-view Console | get-editbox | get-property "getText()" | contains "set_instrument" | verify-true
+		get-view Console | get-editbox | get-property "getText()" | contains "THIS IS " | verify-true
+	}
 }
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998--

--- a/RCPTT_Tests/ScriptingTests/CanControlRunFromScripting.test
+++ b/RCPTT_Tests/ScriptingTests/CanControlRunFromScripting.test
@@ -1,0 +1,43 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Element-Name: CanControlRunFromScripting
+Element-Type: testcase
+Element-Version: 3.0
+External-Reference: 
+Id: _trX9EFDxEeeRb7qwOt4j4g
+Runtime-Version: 2.1.0.201606221726
+Save-Time: 6/14/17 1:23 PM
+Testcase-Type: ecl
+
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
+Content-Type: text/ecl
+Entry-Name: .content
+
+switch_to_scripting_view
+
+with [get-view Console | get-editbox] {
+	type-text "g.begin()"	
+    key-type Enter
+	assert_instrument_is_running
+	
+	type-text "g.pause()"	
+    key-type Enter
+	assert_instrument_is_paused
+	
+	type-text "g.resume()"	
+    key-type Enter
+	assert_instrument_is_running
+	
+	type-text "g.end()"	
+    key-type Enter
+	assert_instrument_is_setup
+	
+	type-text "g.begin()"	
+    key-type Enter
+	assert_instrument_is_running
+	
+	type-text "g.abort()"	
+    key-type Enter
+	assert_instrument_is_setup
+}
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/RCPTT_Tests/ScriptingTests/CanGetAndSetBlocksFromTheScriptingPerspective.test
+++ b/RCPTT_Tests/ScriptingTests/CanGetAndSetBlocksFromTheScriptingPerspective.test
@@ -1,0 +1,58 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Element-Name: CanGetAndSetBlocksFromTheScriptingPerspective
+Element-Type: testcase
+Element-Version: 3.0
+External-Reference: 
+Id: _OZJSQFDbEeebUsTjSlsNqg
+Runtime-Version: 2.1.0.201606221726
+Save-Time: 6/14/17 11:36 AM
+Testcase-Type: ecl
+
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
+Content-Type: text/ecl
+Entry-Name: .content
+
+switch_to_scripting_view
+
+proc cset_value_and_check_with_cshow [val block] [val value] {
+	type-text [concat "g.cset(" $block "=" $value ")"]
+	key-type Enter
+	
+	type-text [concat "g.cshow(\"" $block_name "\")"]
+    key-type Enter
+    try -times 100 -delay 200 -command {
+		get-view Console | get-editbox | get-property "getText()" | contains [concat $block " = " $value] | verify-true
+	}
+}
+
+// Wait for the scripting window to finish starting
+try -times 100 -delay 200 -command {
+	get-view Console | get-editbox | get-property "getText()" | contains "set_instrument" | verify-true
+	get-view Console | get-editbox | get-property "getText()" | contains "THIS IS " | verify-true
+}
+
+// Set up a new configuration with a block
+let [val config_name [test_prefix "scripting_config"]] [val block_name [test_prefix "scripting_block"]] [val pv "SIMPLE:LONG"] [val ioc "SIMPLE"]
+	[val pv_value 1234] [val pv_value_2 5678] {
+	with [new_config] {
+		add_block $block_name $pv
+	    add_ioc_no_macros $ioc
+		save_and_name_config $config_name
+    }
+    load_config $config_name
+    
+	with [get-view Console | get-editbox] {
+		
+		cset_value_and_check_with_cshow $block_name $pv_value
+			
+    	type-text [concat "g.cget(\"" $block_name "\")"]
+    	key-type Enter
+    	try -times 100 -delay 200 -command {
+			get-view Console | get-editbox | get-property "getText()" | contains [concat  "OrderedDict([('name', u'" $block_name "'), ('value', " $pv_value ")" ] | verify-true
+		}
+		
+		cset_value_and_check_with_cshow $block_name $pv_value_2
+	}
+}
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/RCPTT_Tests/ScriptingTests/CanGetAndSetBlocksFromTheScriptingPerspective.test
+++ b/RCPTT_Tests/ScriptingTests/CanGetAndSetBlocksFromTheScriptingPerspective.test
@@ -6,19 +6,14 @@ Element-Version: 3.0
 External-Reference: 
 Id: _OZJSQFDbEeebUsTjSlsNqg
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 11:36 AM
+Save-Time: 6/14/17 1:05 PM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
 Content-Type: text/ecl
 Entry-Name: .content
 
-switch_to_scripting_view
-
-proc cset_value_and_check_with_cshow [val block] [val value] {
-	type-text [concat "g.cset(" $block "=" $value ")"]
-	key-type Enter
-	
+proc verify_cshow [val block] [val value] {
 	type-text [concat "g.cshow(\"" $block_name "\")"]
     key-type Enter
     try -times 100 -delay 200 -command {
@@ -26,15 +21,26 @@ proc cset_value_and_check_with_cshow [val block] [val value] {
 	}
 }
 
-// Wait for the scripting window to finish starting
-try -times 100 -delay 200 -command {
-	get-view Console | get-editbox | get-property "getText()" | contains "set_instrument" | verify-true
-	get-view Console | get-editbox | get-property "getText()" | contains "THIS IS " | verify-true
+proc verify_cget [val block] [val value] {
+    type-text [concat "g.cget(\"" $block_name "\")"]
+    key-type Enter
+    try -times 100 -delay 200 -command {
+		get-view Console | get-editbox | get-property "getText()" | contains [concat  "OrderedDict([('name', u'" $block "'), ('value', " $value ")" ] | verify-true
+	}
 }
 
-// Set up a new configuration with a block
+proc cset_value_and_verify [val block] [val value] {
+	type-text [concat "g.cset(" $block "=" $value ")"]
+	key-type Enter
+	
+	verify_cshow $block $value
+	verify_cget $block $value	
+}
+
 let [val config_name [test_prefix "scripting_config"]] [val block_name [test_prefix "scripting_block"]] [val pv "SIMPLE:LONG"] [val ioc "SIMPLE"]
 	[val pv_value 1234] [val pv_value_2 5678] {
+	
+	// Create and load the config
 	with [new_config] {
 		add_block $block_name $pv
 	    add_ioc_no_macros $ioc
@@ -42,17 +48,27 @@ let [val config_name [test_prefix "scripting_config"]] [val block_name [test_pre
     }
     load_config $config_name
     
-	with [get-view Console | get-editbox] {
-		
-		cset_value_and_check_with_cshow $block_name $pv_value
-			
-    	type-text [concat "g.cget(\"" $block_name "\")"]
-    	key-type Enter
-    	try -times 100 -delay 200 -command {
-			get-view Console | get-editbox | get-property "getText()" | contains [concat  "OrderedDict([('name', u'" $block_name "'), ('value', " $pv_value ")" ] | verify-true
-		}
-		
-		cset_value_and_check_with_cshow $block_name $pv_value_2
+    switch_to_scripting_view
+    
+    // Check that the block is there before continuing
+	try -times 100 -delay 200 -command {
+		get-view Blocks | get-label [concat $block_name ":"] | get-property "getText()" | equals [concat $block_name ":"] | verify-true
 	}
+
+	// Check disconnected values    
+	with [get-view Console | get-editbox] {
+		verify_cget $block_name "None"
+		verify_cshow $block_name "*** disconnected ***"
+	}
+    
+    start_ioc $ioc $block_name
+    
+    // Check connected values
+	with [get-view Console | get-editbox] {
+		cset_value_and_verify $block_name $pv_value
+		cset_value_and_verify $block_name $pv_value_2
+	}
+	
+	stop_ioc $ioc $block_name
 }
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/RCPTT_Tests/rcptt.properties
+++ b/RCPTT_Tests/rcptt.properties
@@ -1,10 +1,10 @@
 --- RCPTT project settings ---
 Format-Version: 1.0
-Contexts: _Opz-IPZyEeWUB6ttFEmy4Q,_08D2QPZgEeWOvoTG7aXu3Q,_uBCfIL41EeaTGY5kC118nA,_mTKdkFVzEeaXbYm3HBnm7g,_u7zXkB5uEeaqQYS4M76Ebw,_BgnBcB5tEeaAYI1qYj9bEg,_oJdLMEdZEeakK_49We-6tQ,_8yQ5kATHEeebWKnhsKxNhg,_yx-k8FokEeaPOv-En4y-qA,_FsR8cEm2Eeamkst2qvREOQ,_xjLrUDb2EeekDKscI2cwGA,_P_dG8EnDEeeQ0ryEI963_g,_BAWr0EbNEeeo0OfG8brAwA,_Pq48EEHeEeaq2ZQRyW_eqw,_nbUl0C4eEea6L74Op-Ffbg,_dwXfYACrEean-631qMZhqw
+Contexts: _Opz-IPZyEeWUB6ttFEmy4Q,_08D2QPZgEeWOvoTG7aXu3Q,_uBCfIL41EeaTGY5kC118nA,_mTKdkFVzEeaXbYm3HBnm7g,_u7zXkB5uEeaqQYS4M76Ebw,_BgnBcB5tEeaAYI1qYj9bEg,_oJdLMEdZEeakK_49We-6tQ,_8yQ5kATHEeebWKnhsKxNhg,_yx-k8FokEeaPOv-En4y-qA,_FsR8cEm2Eeamkst2qvREOQ,_xjLrUDb2EeekDKscI2cwGA,_P_dG8EnDEeeQ0ryEI963_g,_BAWr0EbNEeeo0OfG8brAwA,_6GTDIFDlEeeRb7qwOt4j4g,_Pq48EEHeEeaq2ZQRyW_eqw,_nbUl0C4eEea6L74Op-Ffbg,_dwXfYACrEean-631qMZhqw
 Element-Name: Project Settings
 Element-Type: projectMetadata
 Element-Version: 2.0
 Id: _t199UPZgEeWOvoTG7aXu3Q
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/13/17 12:10 PM
+Save-Time: 6/14/17 1:05 PM
 


### PR DESCRIPTION
### Description of work

Add system tests to test the scripting perspective can:
- Get and set block values
- Start/stop/pause/resume/abort a run

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2377

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code make use of existing procedures where appropriate?
- [x] Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Does the name of the tests reflect what is actually being tested?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated to have entries equivalent to the system tests affected?
    - For example, remove manual tests that are covered by automated tests

### Functional Tests

- [x] Do the new tests pass on a GUI build containing the fix?
- [ ] Do the new tests fail on a GUI build NOT containing the fix (e.g. master)?

