### PR TITLE
HACKATHON: device screens tests

### DIFF
--- a/RCPTT_Tests/AllTests.suite
+++ b/RCPTT_Tests/AllTests.suite
@@ -6,7 +6,7 @@ Element-Version: 2.0
 Id: _wMLmwPZgEeWOvoTG7aXu3Q
 Manually-Ordered: true
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 3:40 PM
+Save-Time: 6/14/17 3:59 PM
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8
 Content-Type: text/testcase
@@ -63,6 +63,5 @@ _I072oExYEeehx9brc2-KyQ	// kind: 'test' name: 'WhenAConfigIsSavedAsAComponentThe
 _bpiCAEzwEee1irVDJO9Pmw	// kind: 'test' name: 'WhenComponetGroupRemovedItIsRemovedFromConfig' path: 'GroupTests/WhenComponetGroupRemovedItIsRemovedFromConfig.test'
 _BHV84FBKEeebUsTjSlsNqg	// kind: 'test' name: 'CheckForBasicBeamStatusInformation' path: 'BeamStatusTests/CheckForBasicBeamStatusInformation.test'
 _Iokw4FDSEeebUsTjSlsNqg	// kind: 'test' name: 'DashboardInformationAvailableOnStartup' path: 'DashboardInformationAvailableOnStartup.test'
-_UPh6MFEEEeeN-J8cVhSWtw	// kind: 'test' name: 'OnlyServerDeviceScreensArePreservedOnRestart' path: 'Devicescreens/OnlyServerDeviceScreensArePreservedOnRestart.test'
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8--

--- a/RCPTT_Tests/AllTests.suite
+++ b/RCPTT_Tests/AllTests.suite
@@ -6,7 +6,7 @@ Element-Version: 2.0
 Id: _wMLmwPZgEeWOvoTG7aXu3Q
 Manually-Ordered: true
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 9:42 AM
+Save-Time: 6/14/17 3:40 PM
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8
 Content-Type: text/testcase
@@ -63,5 +63,6 @@ _I072oExYEeehx9brc2-KyQ	// kind: 'test' name: 'WhenAConfigIsSavedAsAComponentThe
 _bpiCAEzwEee1irVDJO9Pmw	// kind: 'test' name: 'WhenComponetGroupRemovedItIsRemovedFromConfig' path: 'GroupTests/WhenComponetGroupRemovedItIsRemovedFromConfig.test'
 _BHV84FBKEeebUsTjSlsNqg	// kind: 'test' name: 'CheckForBasicBeamStatusInformation' path: 'BeamStatusTests/CheckForBasicBeamStatusInformation.test'
 _Iokw4FDSEeebUsTjSlsNqg	// kind: 'test' name: 'DashboardInformationAvailableOnStartup' path: 'DashboardInformationAvailableOnStartup.test'
+_UPh6MFEEEeeN-J8cVhSWtw	// kind: 'test' name: 'OnlyServerDeviceScreensArePreservedOnRestart' path: 'Devicescreens/OnlyServerDeviceScreensArePreservedOnRestart.test'
 
 ------=_testcase-items-62c497da-4241-31f4-811a-6b453a3ecff8--

--- a/RCPTT_Tests/Contexts/DeviceScreensProcedures.ctx
+++ b/RCPTT_Tests/Contexts/DeviceScreensProcedures.ctx
@@ -6,7 +6,7 @@ Element-Type: context
 Element-Version: 2.0
 Id: _P_dG8EnDEeeQ0ryEI963_g
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/9/17 10:49 AM
+Save-Time: 6/14/17 3:32 PM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl
@@ -34,13 +34,21 @@ proc "device_screens_group" [val window -input true] {
 // param group (input) - the device screen group on the edit window
 //       name - name of screen
 //       targetName - name of the target
-proc "add_screen_with_target" [val window -input true] [val name] [val targetName -value "Analyser"] {
+proc "add_screen_with_target" [val window -input true] [val name] [val save_on_server -value false] [val targetName -value "Analyser"] {
     with $window {    
         with [device_screens_group] {
 	        get-button Add | check_button_enabled_and_click
 	    }
-	
+	    
+	    if 
+        get-button "Save this device screen" | click
+		
 		with [get-group Target] {
+			if [$save_on_server | eq true] -then {
+        		get-button "Save this device screen" | click
+        	} -else {
+        		get-button "Remove this device screen when IBEX is closed" | click
+        	}
 	    	get-editbox -after [get-label Name] | set-text $name
 	    	get-combo -after [get-label Target] | select $targetName
 		}

--- a/RCPTT_Tests/Contexts/RestartAUT.ctx
+++ b/RCPTT_Tests/Contexts/RestartAUT.ctx
@@ -5,8 +5,8 @@ Element-Name: RestartAUT
 Element-Type: context
 Element-Version: 2.0
 Id: _uBCfIL41EeaTGY5kC118nA
-Runtime-Version: 2.0.1.201508250612
-Save-Time: 1/5/17 10:06 PM
+Runtime-Version: 2.1.0.201606221726
+Save-Time: 6/14/17 3:11 PM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl

--- a/RCPTT_Tests/Devicescreens/AddAndDeleteDeviceScreens.test
+++ b/RCPTT_Tests/Devicescreens/AddAndDeleteDeviceScreens.test
@@ -6,7 +6,7 @@ Element-Version: 3.0
 External-Reference: 
 Id: _xCZlkAirEeewRLVbkB4NiA
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 2:52 PM
+Save-Time: 6/14/17 3:21 PM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
@@ -16,55 +16,47 @@ Entry-Name: .content
 // Test device screens can be added and deleted
 
 switch_to_device_screens_view
-
-let [ val device_screen_count [get-table | get-property "itemCount" -raw true]] {
-
-	let [val screen01 [test_prefix "test_screen"]] [val screen02 [test_prefix "test_screen_01"]] 
-		[val screen03 [test_prefix "test_screen_02"]] {
+let [ val device_screen_count [get-table | get-property "itemCount" -raw true]] 
+	[val screen01 [test_prefix "test_screen_01"]] [val screen02 [test_prefix "test_screen_02"]] 
+	[val screen03 [test_prefix "test_screen_03"]] {
 		
-		// Check that screen can't be added without a target
-        with [edit_device_screens] {	    
-        	get-button Add | check_button_enabled_and_click
+	// Check that screen can't be added without a target
+    with [edit_device_screens] {	    
+    	get-button Add | check_button_enabled_and_click
         	
-	    	// Is there error text? Don't use the full text because it'll be fragile but I expect it should suggest the target
-	    	// as the problem    
-    		get-editbox -after [get-label "Configure Device Screens"] | get-property text | contains "target" | verify-true
+	    // Is there error text? Don't use the full text because it'll be fragile but I expect it should suggest the target
+	    // as the problem    
+    	get-editbox -after [get-label "Configure Device Screens"] | get-property text | contains "target" | verify-true
     	
-    		// We shouldn't be able to press OK
-			get-button OK | get-property enablement | equals false | verify-true
-			
-			check_button_enabled_and_click [get-button Cancel]
-		}		
+    	// We shouldn't be able to press OK
+		get-button OK | get-property enablement | equals false | verify-true
 		
-		// add screens
-		with [edit_device_screens] {
-			add_screen_with_target $screen01
-			add_screen_with_target $screen02
-			add_screen_with_target $screen03
+		check_button_enabled_and_click [get-button Cancel]
+	}		
+		
+	// add screens
+	with [edit_device_screens] {
+		add_screen_with_target $screen01
+		add_screen_with_target $screen02
+		add_screen_with_target $screen03
 	
-	    	get-button OK | check_button_enabled_and_click
-		}
-		
-		// verify screens have appeared
-		get-table | get-item $screen01 -column Name | get-property "columns[1]" | equals $screen01 | verify-true
-		get-table | get-item $screen02 -column Name | get-property "columns[1]" | equals $screen02 | verify-true
-		get-table | get-item $screen03 -column Name | get-property "columns[1]" | equals $screen03 | verify-true
-		
-		// delete added screens	
-	    with [edit_device_screens] {
-		    with [device_screens_group] {
-		        get-list | select $screen01
-		        get-button Delete | click
-		        get-list | select $screen02 $screen03
-		        get-button Delete | click
-			}
-			get-button OK | click
-		}
-		
+	   	get-button OK | check_button_enabled_and_click
 	}
-
-    // ensure extra device screens that were added have been deleted
-    get-table | get-property "itemCount" | equals $device_screen_count | verify-true
+		
+	// verify screens have appeared
+	get-table | get-item $screen01 -column Name | get-property "columns[1]" | equals $screen01 | verify-true
+	get-table | get-item $screen02 -column Name | get-property "columns[1]" | equals $screen02 | verify-true
+	get-table | get-item $screen03 -column Name | get-property "columns[1]" | equals $screen03 | verify-true
+		
+	// delete added screens	
+	with [edit_device_screens] {
+		with [device_screens_group] {
+		    get-list | select $screen01
+		    get-button Delete | click
+		    get-list | select $screen02 $screen03
+		    get-button Delete | click
+		}
+		get-button OK | click
+	}
 }
-
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/RCPTT_Tests/Devicescreens/AddAndDeleteDeviceScreens.test
+++ b/RCPTT_Tests/Devicescreens/AddAndDeleteDeviceScreens.test
@@ -6,7 +6,7 @@ Element-Version: 3.0
 External-Reference: 
 Id: _xCZlkAirEeewRLVbkB4NiA
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/5/17 2:28 PM
+Save-Time: 6/14/17 2:52 PM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
@@ -21,6 +21,20 @@ let [ val device_screen_count [get-table | get-property "itemCount" -raw true]] 
 
 	let [val screen01 [test_prefix "test_screen"]] [val screen02 [test_prefix "test_screen_01"]] 
 		[val screen03 [test_prefix "test_screen_02"]] {
+		
+		// Check that screen can't be added without a target
+        with [edit_device_screens] {	    
+        	get-button Add | check_button_enabled_and_click
+        	
+	    	// Is there error text? Don't use the full text because it'll be fragile but I expect it should suggest the target
+	    	// as the problem    
+    		get-editbox -after [get-label "Configure Device Screens"] | get-property text | contains "target" | verify-true
+    	
+    		// We shouldn't be able to press OK
+			get-button OK | get-property enablement | equals false | verify-true
+			
+			check_button_enabled_and_click [get-button Cancel]
+		}		
 		
 		// add screens
 		with [edit_device_screens] {

--- a/RCPTT_Tests/Devicescreens/OnlyServerDeviceScreensArePreservedOnRestart.test
+++ b/RCPTT_Tests/Devicescreens/OnlyServerDeviceScreensArePreservedOnRestart.test
@@ -1,0 +1,43 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Element-Name: OnlyServerDeviceScreensArePreservedOnRestart
+Element-Type: testcase
+Element-Version: 3.0
+External-Reference: 
+Id: _UPh6MFEEEeeN-J8cVhSWtw
+Runtime-Version: 2.1.0.201606221726
+Save-Time: 6/14/17 3:35 PM
+Testcase-Type: ecl
+
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
+Content-Type: text/ecl
+Entry-Name: .content
+
+switch_to_device_screens_view 
+
+// Add the screens
+let [val server_screen [test_prefix "server_screen"]] [val local_screen [test_prefix "local_screen"]] {
+    with [edit_device_screens] {
+		add_screen_with_target $local_screen
+		add_screen_with_target $server_screen true
+	   	get-button OK | check_button_enabled_and_click
+	} 
+}
+
+// Restart Ibex
+// We have to do this outside let or RCPTT will "Fail to close report node"
+restart-aut
+check_button_enabled_and_click [get-window "Close the application?" | get-button Yes]
+wait-until-eclipse-is-ready
+
+// Check that only the server screen is still available
+let	[val server_screen [test_prefix "server_screen"]] [val local_screen [test_prefix "local_screen"]] {
+    try -times 100 -delay 200 -command {
+    	switch_to_device_screens_view
+    	get-table | get-property "itemCount" -raw true | equals 1 | verify-true
+    	with [edit_device_screens] {
+			get-table | get-item $server_screen -column Name | get-property "columns[1]" | equals $server_screen | verify-true
+		}
+	}
+}
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--

--- a/RCPTT_Tests/Devicescreens/OnlyServerDeviceScreensArePreservedOnRestart.test
+++ b/RCPTT_Tests/Devicescreens/OnlyServerDeviceScreensArePreservedOnRestart.test
@@ -6,7 +6,7 @@ Element-Version: 3.0
 External-Reference: 
 Id: _UPh6MFEEEeeN-J8cVhSWtw
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 6/14/17 3:35 PM
+Save-Time: 6/14/17 3:46 PM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
@@ -21,6 +21,7 @@ let [val server_screen [test_prefix "server_screen"]] [val local_screen [test_pr
 		add_screen_with_target $local_screen
 		add_screen_with_target $server_screen true
 	   	get-button OK | check_button_enabled_and_click
+	   	wait 5000
 	} 
 }
 
@@ -32,7 +33,7 @@ wait-until-eclipse-is-ready
 
 // Check that only the server screen is still available
 let	[val server_screen [test_prefix "server_screen"]] [val local_screen [test_prefix "local_screen"]] {
-    try -times 100 -delay 200 -command {
+    try -times 20 -delay 200 -command {
     	switch_to_device_screens_view
     	get-table | get-property "itemCount" -raw true | equals 1 | verify-true
     	with [edit_device_screens] {


### PR DESCRIPTION
### Description of work

I've added the following tests:
- Check that an error is displayed if no target is defined for a new device screen and don't allow it to be saved
- Check that only server device screens are saved between restarts of Ibex

Note that the 2nd test genuinely fails. I've checked on mine and @Tom-Willemsen's machine. I've created a ticket to address this issue (https://github.com/ISISComputingGroup/IBEX/issues/2420) and add the test to the suite when the functionality is fixed.

### To test

ISISComputingGroup/IBEX#2377

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code make use of existing procedures where appropriate?
- [ ] Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Does the name of the tests reflect what is actually being tested?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated to have entries equivalent to the system tests affected?
    - For example, remove manual tests that are covered by automated tests

### Functional Tests

- [ ] Do the new tests pass on a GUI build containing the fix?
- [ ] Do the new tests fail on a GUI build NOT containing the fix (e.g. master)?

