### PR TITLE
Fix failing configuration edit test

### DIFF
--- a/RCPTT_Tests/ConfigurationTests/CanEditPreviousConfigs.test
+++ b/RCPTT_Tests/ConfigurationTests/CanEditPreviousConfigs.test
@@ -5,8 +5,8 @@ Element-Type: testcase
 Element-Version: 3.0
 External-Reference: 
 Id: _Xt7pAE5hEeaUKeYJFOSZaA
-Runtime-Version: 2.1.0.201606221726
-Save-Time: 3/22/17 2:30 PM
+Runtime-Version: 2.0.1.201508250612
+Save-Time: 8/18/17 11:49 AM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
@@ -36,7 +36,9 @@ let [val config01 [test_prefix "config01"]] {
 
 	//Confirm window opens
 	try -times 50 -delay 500 -command {	  
-	  get-window "Edit Configuration" | get-label "Editing the current configuration" | get-property "getText()" | equals "Editing the current configuration" | verify-true
+	  let [val subtitle [concat "Editing the " $config01 " configuration"]] {
+	  	get-window "Edit Configuration" | get-label $subtitle | get-property "getText()" | equals $subtitle | verify-true
+	  }
 	}
 }
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--


### PR DESCRIPTION
### Description of work

This fixes the failing system test "CanEditPreviousConfig" in Configuration Tests

### To test
 - Test pass.
 - Code review

This is part of:
https://github.com/ISISComputingGroup/IBEX/issues/2536

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code make use of existing procedures where appropriate?
- [ ] Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Does the name of the tests reflect what is actually being tested?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated to have entries equivalent to the system tests affected?
    - For example, remove manual tests that are covered by automated tests

### Functional Tests

- [ ] Do the new tests pass on a GUI build containing the fix?
- [ ] Do the new tests fail on a GUI build NOT containing the fix (e.g. master)?

