### PR TITLE
Ticket 2296: Fixed test to work with axis description in table of motors

### DIFF
--- a/RCPTT_Tests/Contexts/MotorProcedures.ctx
+++ b/RCPTT_Tests/Contexts/MotorProcedures.ctx
@@ -6,7 +6,7 @@ Element-Type: context
 Element-Version: 2.0
 Id: _FsR8cEm2Eeamaaa2qvREOQ
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 7/4/17 2:05 PM
+Save-Time: 10/19/17 7:37 PM
 
 ------=_.ecl.context-718f04b4-ed39-33e3-af62-0995e4561998
 Content-Type: text/ecl
@@ -31,13 +31,13 @@ proc assert_wait_for_opi_to_be_closed [val name] {
 	}
 }
 
-proc configure_galil [val galilname] [val galilmacro] {
-	let [val window [edit_current_config]] {
-		add_ioc -ioc_name $galilname -window $window
-		add_ioc_macro $galilmacro "1.2.3.4"
-		add_autostart_and_recsim_to_ioc -iocname $galilname -window $window
-		save_config
-	}
+proc configure_galil [val galilname] [val galilmacro] [val window -input true] {
+	add_ioc -ioc_name $galilname -window $window
+	log -message "config" 
+	add_ioc_macro $galilmacro "1.2.3.4"
+	log -message "add macro"
+	add_autostart_and_recsim_to_ioc -iocname $galilname -window $window
+	log -message "autostart"
 }
 
 proc add_autostart_and_recsim_to_ioc [val iocname] [val window] {

--- a/RCPTT_Tests/MotorTests/RunningMotorsAppearProperly.test
+++ b/RCPTT_Tests/MotorTests/RunningMotorsAppearProperly.test
@@ -6,7 +6,7 @@ Element-Version: 3.0
 External-Reference: 
 Id: _VXHlcFDlEeen85wkhybD2Q
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 7/5/17 9:48 AM
+Save-Time: 10/24/17 10:23 AM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
@@ -14,30 +14,30 @@ Content-Type: text/ecl
 Entry-Name: .content
 
 let [val configname [test_prefix "motors_config01"]] {
-	create_empty_config -config_name $configname
+	with [new_config] {
+		set_config_description $configname
+		configure_galil -galilname "GALIL_01" -galilmacro "GALILADDR01"
+		save_and_name_config $configname
+	}
 	load_config -name $configname
 }
 
-configure_galil -galilname "GALIL_01" -galilmacro "GALILADDR01"
-
 switch_to_motors_view
 
-try -times 100 -delay 200 -command {
+try -times 10 -delay 200 -command {
 	with [get-view "Additional Motors (Controllers 9 - 16)"] {
-    	get-control Any -after [get-label MTR0901] -index 2 | double-click
+    	get-control Any -after [get-label 9] | get-property backgroundColor | equals "#C8C8C8" | verify-true
 	}
-	get-view Unknown | get-property enablement | equals true | verify-true
 }
 
-try -times 100 -delay 200 -command {
+try -times 20 -delay 200 -command {
 	with [get-view "Main Motors (Controllers 1 - 8)"] {	
 		// Slightly messy way to grab the top-left item in the grid... 
 	    get-control Any -after [get-label 8] -index 2 | get-property backgroundColor | equals "#FFC8C8" | verify-true 
 	    // Double click the top-left item in the grid...   
-    	get-control Any -after [get-label MTR0101] -index 2 | double-click
+    	get-control Any -after [get-label 1 -after [get-label 8]] | double-click
 	}
 	// ... and verify that it has opened the correct OPI.
 	get-view "MTR0101 (GALIL)" | get-property enablement | equals true | verify-true
 }
-
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--


### PR DESCRIPTION
### Description of work

Fixed test to work with https://github.com/ISISComputingGroup/ibex_gui/pull/585

It would be nice to be able to test the functionality that the above ticket introduces but setting the motor description PV from the GUI is currently tricky. We could use a PV value in the config but then the instrument prefix must b found, which could be a little tricky, maybe after https://github.com/ISISComputingGroup/IBEX/issues/1452

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code make use of existing procedures where appropriate?
- [x] Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Does the name of the tests reflect what is actually being tested?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated to have entries equivalent to the system tests affected?
    - For example, remove manual tests that are covered by automated tests

### Functional Tests

- [x] Do the new tests pass on a GUI build containing the fix?
- [x] Do the new tests fail on a GUI build NOT containing the fix (e.g. master)?

