### PR TITLE
Add start and stop runs to useful tools.

### DIFF
--- a/RCPTT_Tests/UsefulTools/StartAndStopManyRuns.test
+++ b/RCPTT_Tests/UsefulTools/StartAndStopManyRuns.test
@@ -6,19 +6,22 @@ Element-Version: 3.0
 External-Reference: 
 Id: _BRhOEM31EeetfcaUrAi48g
 Runtime-Version: 2.1.0.201606221726
-Save-Time: 11/20/17 2:44 PM
+Save-Time: 11/20/17 5:13 PM
 Testcase-Type: ecl
 
 ------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
 Content-Type: text/ecl
 Entry-Name: .content
 
+set-q7-option timeout 72000 // 20 hours
+set-q7-option testExecTimeout 72000 // 20 hours
+set-q7-option eclExecutionDelay 1
+
+
 loop [val count 0] {
-	if [$count | lt 30] {
+	if [$count | lt 2000] {
 		 begin_run
-		 sleep 500;
 		 end_run
-		 sleep 500;
 		 recur [$count | plus 1]
 	}
 }

--- a/RCPTT_Tests/UsefulTools/StartAndStopManyRuns.test
+++ b/RCPTT_Tests/UsefulTools/StartAndStopManyRuns.test
@@ -1,0 +1,25 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Element-Name: StartAndStopManyRuns
+Element-Type: testcase
+Element-Version: 3.0
+External-Reference: 
+Id: _BRhOEM31EeetfcaUrAi48g
+Runtime-Version: 2.1.0.201606221726
+Save-Time: 11/20/17 2:44 PM
+Testcase-Type: ecl
+
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac
+Content-Type: text/ecl
+Entry-Name: .content
+
+loop [val count 0] {
+	if [$count | lt 30] {
+		 begin_run
+		 sleep 500;
+		 end_run
+		 sleep 500;
+		 recur [$count | plus 1]
+	}
+}
+------=_.content-0a7243a0-75d3-3d5f-9791-539de0e5b7ac--


### PR DESCRIPTION
### Description of work

Adds a helper RCPTT test to reproduce the error in the ticket linked below.

This is not intended to be run as part of the main test suite but I have included it as a "useful tool" because it may be useful again in future.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2643

Testing method is detailed in the GUI pull request

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code make use of existing procedures where appropriate?
- [x] Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Does the name of the tests reflect what is actually being tested?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated to have entries equivalent to the system tests affected?
    - For example, remove manual tests that are covered by automated tests

### Functional Tests

- [ ] Do the new tests pass on a GUI build containing the fix?
- [ ] Do the new tests fail on a GUI build NOT containing the fix (e.g. master)?

